### PR TITLE
Add node script that executes our binary to appease yarn

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -1,10 +1,11 @@
 #! /usr/bin/env node
 
 const { execFileSync } = require('child_process');
+const path = require('path');
 
 if (process.platform !== 'darwin') {
   console.error('This command only supports MacOS/Darwin');
   process.exit(1);
 }
 
-execFileSync('../dist/to_json');
+execFileSync(path.resolve(__dirname, '../dist/to_json'));

--- a/bin/index.js
+++ b/bin/index.js
@@ -1,0 +1,10 @@
+#! /usr/bin/env node
+
+const { execFileSync } = require('child_process');
+
+if (process.platform !== 'darwin') {
+  console.error('This command only supports MacOS/Darwin');
+  process.exit(1);
+}
+
+execFileSync('../dist/to_json');

--- a/bin/index.js
+++ b/bin/index.js
@@ -8,10 +8,16 @@ if (process.platform !== 'darwin') {
   process.exit(1);
 }
 
-const child = execFile(path.resolve(__dirname, '../dist/to_json'), [
-  process.argv[2] || '',
-  process.argv[3] || '',
-]);
+const child = execFile(
+  path.resolve(__dirname, '../dist/to_json'),
+  [process.argv[2] || '', process.argv[3] || ''],
+  (error) => {
+    if (error) {
+      console.error(error);
+      process.exit(1);
+    }
+  }
+);
 
 child.stdout.pipe(process.stdout);
 child.stderr.pipe(process.stderr);

--- a/bin/index.js
+++ b/bin/index.js
@@ -1,6 +1,6 @@
 #! /usr/bin/env node
 
-const { execFileSync } = require('child_process');
+const { execFile } = require('child_process');
 const path = require('path');
 
 if (process.platform !== 'darwin') {
@@ -8,4 +8,10 @@ if (process.platform !== 'darwin') {
   process.exit(1);
 }
 
-execFileSync(path.resolve(__dirname, '../dist/to_json'));
+const child = execFile(path.resolve(__dirname, '../dist/to_json'), [
+  process.argv[2] || '',
+  process.argv[3] || '',
+]);
+
+child.stdout.pipe(process.stdout);
+child.stderr.pipe(process.stderr);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Documentation and tools for converting LevelDB files into JSON files. (eg. for reading Google Firestore and Datastore backups)",
   "main": "index.js",
   "bin": {
-    "firestore-to-json": "./dist/to_json"
+    "firestore-to-json": "./bin/index.js"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Documentation and tools for converting LevelDB files into JSON files. (eg. for reading Google Firestore and Datastore backups)",
   "main": "index.js",
   "bin": {
-    "firestore-to-json": "./bin/index.js"
+    "firestore-to-json": "./bin/index.js",
+    "__firestore-to-json": "./dist/to_json"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/src/to_json.py
+++ b/src/to_json.py
@@ -74,7 +74,7 @@ def json_serialize_func(obj):
             obj.microsecond / 1000
         )
         return millis
-    # raise TypeError('Not sure how to serialize %s' % (obj,))
+    # raise TypeError("Not sure how to serialize %s" % (obj,))
     return str(obj)
 
 
@@ -92,7 +92,7 @@ def init():
         print("Reading from: " + filename)
 
         in_path = os.path.join(backup_folder, filename)
-        raw = open(in_path, 'rb')
+        raw = open(in_path, "rb")
         reader = records.RecordsReader(raw)
         for record_index, record in enumerate(reader):
             entity_proto = entity_pb.EntityProto(contents=record)
@@ -109,7 +109,7 @@ def init():
 
             print("Parsing document: #" + str(len(items)))
 
-    out = open(out_path, 'w')
+    out = open(out_path, "w")
     out.write(json.dumps(json_tree, default=json_serialize_func, indent=2).encode("utf-8"))
     out.close()
     print("JSON file written to: " + out_path)

--- a/src/to_json.py
+++ b/src/to_json.py
@@ -9,11 +9,10 @@ from google.appengine.api import datastore
 cwd = os.getcwd()
 # repo_root = os.path.dirname(os.path.realpath(__file__))
 
-
-if len(sys.argv) < 2:
+if len(sys.argv) < 2 or not sys.argv[1]:
     sys.exit("No firestore backup folder specified")
 
-if len(sys.argv) < 3:
+if len(sys.argv) < 3 or not sys.argv[2]:
     sys.exit("No outfile specified")
 
 backup = sys.argv[1]

--- a/src/to_json.py
+++ b/src/to_json.py
@@ -110,8 +110,7 @@ def init():
             print("Parsing document: #" + str(len(items)))
 
     out = open(out_path, 'w')
-    out.write(json.dumps(json_tree, default=json_serialize_func,
-                         encoding='latin-1', indent=2))
+    out.write(json.dumps(json_tree, default=json_serialize_func, indent=2).encode("utf-8"))
     out.close()
     print("JSON file written to: " + out_path)
 


### PR DESCRIPTION
Note: the additional `__firestore-to-json` binary is required for the binary to be marked as executable by yarn, otherwise we get EACCES errors.

Also ensures output JSON is UTF8 encoded.